### PR TITLE
Fix CurlDownload speed property

### DIFF
--- a/src/pyload/requests/curl/download.py
+++ b/src/pyload/requests/curl/download.py
@@ -38,7 +38,7 @@ class CurlDownload(DownloadRequest):
 
     if os.name == 'nt':
         PATH_MAXLEN = 255
-    else sys.platform == 'darwin':
+    elif sys.platform == 'darwin':
         PATH_MAXLEN = 1024
     else:
         PATH_MAXLEN = 4096
@@ -61,7 +61,7 @@ class CurlDownload(DownloadRequest):
 
     @property
     def speed(self):
-        last = (sum(x) for x in self.last_speeds if x)
+        last = [sum(x) for x in self.last_speeds if x]
         return (sum(self.speeds) + sum(last)) // (1 + len(last))
 
     @property


### PR DESCRIPTION
This was changed from a list comprehension to a generator in commit 80ef71e0202f2e6e437daecaec1c9bbc5b36690f. However, the line after it makes it fail because a generator doesn't have length. And even if it had a length, the generator is already consumed by the `sum(speeds)` operation.

Also fixed an invalid `else`.