### PR TITLE
Migrate the Connection datatype from pyload.core

### DIFF
--- a/src/pyload/requests/curl/download.py
+++ b/src/pyload/requests/curl/download.py
@@ -16,7 +16,7 @@ import pycurl
 from pyload.utils import purge
 from pyload.utils.fs import fullpath, lopen, remove
 
-from ...datatype import Connection
+from pyload.requests.types import Connection
 from ..chunk import ChunkInfo
 from ..cookie import CookieJar
 from ..download import DownloadRequest

--- a/src/pyload/requests/types.py
+++ b/src/pyload/requests/types.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+from future import standard_library
+
+try:
+    from enum import IntEnum
+except ImportError:
+    from aenum import IntEnum
+
+standard_library.install_aliases()
+
+
+class Connection(IntEnum):
+    All = 0
+    Resumable = 1
+    Secure = 2


### PR DESCRIPTION
`Connection` is used by `requests` but is currently implemented in the core repository. Migrate it to this repo, and it can be completely removed from core as (AFAIK) it's not being used anywhere else.